### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/shannonmae0360/2823fa04-919a-4b39-8649-2e96cfaaa64e/bdf1e906-11fb-43f7-9182-9acb6eaa6159/_apis/work/boardbadge/4f125543-9dc7-4abd-b778-38ccfa41383f)](https://dev.azure.com/shannonmae0360/2823fa04-919a-4b39-8649-2e96cfaaa64e/_boards/board/t/bdf1e906-11fb-43f7-9182-9acb6eaa6159/Microsoft.RequirementCategory)
 # hello-world-1
  


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/shannonmae0360/2823fa04-919a-4b39-8649-2e96cfaaa64e/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.